### PR TITLE
JNG-4380 Upload and Download servlet name have to be defined to avoid…

### DIFF
--- a/filestore-servlet/src/main/java/hu/blackbelt/osgi/filestore/servlet/DownloadServlet.java
+++ b/filestore-servlet/src/main/java/hu/blackbelt/osgi/filestore/servlet/DownloadServlet.java
@@ -126,7 +126,7 @@ public class DownloadServlet extends HttpServlet {
 
         httpService.registerServlet(servletPath, this, getInitParams(servletPath), null);
     }
-Rdbms
+
     @Deactivate
     protected void deactivate() {
         httpService.unregister(servletPath);

--- a/filestore-servlet/src/main/java/hu/blackbelt/osgi/filestore/servlet/DownloadServlet.java
+++ b/filestore-servlet/src/main/java/hu/blackbelt/osgi/filestore/servlet/DownloadServlet.java
@@ -124,9 +124,9 @@ public class DownloadServlet extends HttpServlet {
         servletPath = config.servletPath();
         tokenRequired = config.tokenRequired();
 
-        httpService.registerServlet(servletPath, this, null, null);
+        httpService.registerServlet(servletPath, this, getInitParams(servletPath), null);
     }
-
+Rdbms
     @Deactivate
     protected void deactivate() {
         httpService.unregister(servletPath);
@@ -214,4 +214,11 @@ public class DownloadServlet extends HttpServlet {
             PER_THREAD_REQUEST.set(null);
         }
     }
+
+    private Dictionary getInitParams(String name) {
+        Dictionary dictionary = new Hashtable();
+        dictionary.put("servlet-name", "DownloadServlet-" + name);
+        return dictionary;
+    }
+
 }

--- a/filestore-servlet/src/main/java/hu/blackbelt/osgi/filestore/servlet/UploadServlet.java
+++ b/filestore-servlet/src/main/java/hu/blackbelt/osgi/filestore/servlet/UploadServlet.java
@@ -146,7 +146,7 @@ public class UploadServlet extends HttpServlet implements Servlet {
         tokenRequired = config.tokenRequired();
 
         log.info(String.format(MSG_INIT_MAX_SIZE_D_UPLOAD_DELAY_D_CORS_REGEX_S, maxSize, uploadDelay, corsProcessor.getAllowOrigins()));
-        httpService.registerServlet(servletPath, this, null, null);
+        httpService.registerServlet(servletPath, this, getInitParams(servletPath), null);
     }
 
     @Deactivate
@@ -606,4 +606,11 @@ public class UploadServlet extends HttpServlet implements Servlet {
             listener.remove();
         }
     }
+
+    private Dictionary getInitParams(String name) {
+        Dictionary dictionary = new Hashtable();
+        dictionary.put("servlet-name", "UploadServlet-" + name);
+        return dictionary;
+    }
+
 }


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://blackbelt.atlassian.net/browse/JNG-4380" title="JNG-4380" target="_blank"><img alt="Bug" src="https://blackbelt.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10303?size=medium" />JNG-4380</a>  Servlet registration in newer Http whiteboard throw error when servlet name not given
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->
<!--do not remove this marker, its needed to replace info when ticket title is updated -->

… collosion because of the derived servlet name from class name